### PR TITLE
fix(formatting): Added workaround to move color to top of the style tree

### DIFF
--- a/src/Service/draftEditor.service.tsx
+++ b/src/Service/draftEditor.service.tsx
@@ -95,7 +95,28 @@ const formatText = (editorState: EditorState, formatType: string, value: string)
     if (!currentStyle.has(value)) {
         nextEditorState = RichUtils.toggleInlineStyle(nextEditorState, value);
     }
-    return nextEditorState;
+    return moveColorToTop(nextEditorState);
+};
+
+const moveColorToTop = (editorState: EditorState) => {
+    const selection = editorState.getSelection();
+    const currentStyleBefore = editorState.getCurrentInlineStyle();
+    let contentState = editorState.getCurrentContent();
+
+    const colorStyle = currentStyleBefore.find((item) => item && item.includes(`${formatKeys.color}__`));
+    if (currentStyleBefore.first() !== colorStyle) {
+        currentStyleBefore.forEach((item) => {
+            contentState = Modifier.removeInlineStyle(contentState, selection, item);
+        });
+        if (colorStyle) contentState = Modifier.applyInlineStyle(contentState, selection, colorStyle);
+        currentStyleBefore.forEach((item) => {
+            if (item && item !== colorStyle) {
+                contentState = Modifier.applyInlineStyle(contentState, selection, item);
+            }
+        });
+        return EditorState.push(editorState, contentState, 'change-inline-style');
+    }
+    return editorState;
 };
 
 const getContentFromEditorState = (editorStateUpdated: EditorState) => {


### PR DESCRIPTION


# Changes Made On Draft Editor

1.  [x] Editor
2.  [ ] Toolbar

# Purpose of change

-   [ ] NEW FEATURE IMPLEMENTATION
-   [ ] CODE QUALITY IMPROVEMENT
-   [x] BUG FIX
-   [ ] Version Updation

# Description of change
Added workaround to move color to top of the style tree so that if a underline is added the color is not adding to it.

<!-- Use '@' to mention the reviewer -->
# Reviewer
@nsdevaraj 