### PR TITLE
mention customization and drafteditor customization added

### DIFF
--- a/src/DraftEditor.tsx
+++ b/src/DraftEditor.tsx
@@ -5,6 +5,7 @@ import createLinkifyPlugin from 'draft-js-link-detection-plugin';
 import '@draft-js-plugins/mention/lib/plugin.css';
 import {
     convertToRaw,
+    DraftDecorator,
     EditorState,
     getDefaultKeyBinding,
     KeyBindingUtil,
@@ -62,6 +63,7 @@ interface IDraftEditorProps {
     onSelection?: (editorStateUpdated: EditorState) => void;
     ValuePopOverProps?: (props) => JSX.Element;
     updateFormat?: (format: IElementFormats) => void;
+    decorators?: DraftDecorator[];
 }
 export interface IElementFormats {
     fontFamily?: string;
@@ -239,7 +241,6 @@ class DraftEditor extends Component<IDraftEditorProps, IDraftEditorState> {
     };
 
     onEditorStateChange = (editorStateUpdated: EditorState) => {
-        // const editorState = this.onEditorTextChange(editorStateUpdated);
         this.props.onSelection?.(editorStateUpdated);
         this.updateData(editorStateUpdated);
     };
@@ -311,20 +312,6 @@ class DraftEditor extends Component<IDraftEditorProps, IDraftEditorState> {
         // }
     };
 
-    onEditorTextChange = (editorStateUpdated: EditorState) => {
-        const html = convertToHTMLString(
-            editorStateUpdated,
-            this.props.isColorRequired,
-            !!this.props.ValuePopOverProps,
-        );
-        const editorState = EditorState.createWithContent(convertFromHTMLString(html));
-
-        this.setState({
-            editorState: editorState,
-        });
-        return editorState;
-    };
-
     handleKeyCommand = (command: string, editorStateUpdated: EditorState) => {
         if (command === 'submit' && this.props.submit) {
             this.props.submit();
@@ -361,7 +348,7 @@ class DraftEditor extends Component<IDraftEditorProps, IDraftEditorState> {
     };
 
     MentionComponents = () => {
-        const { showMention } = this.props;
+        const { showMention, decorators } = this.props;
         const mentionPlugin_PREFIX_ONE = showMention.people
             ? createMentionPlugin({
                   mentionTrigger: MENTION_SUGGESTION_NAME.PREFIX_ONE,
@@ -383,6 +370,10 @@ class DraftEditor extends Component<IDraftEditorProps, IDraftEditorState> {
 
         // eslint-disable-next-line no-shadow
         const plugins: any = [linkifyPlugin];
+
+        if (decorators) {
+            plugins.push({ decorators });
+        }
         if (showMention.people) {
             plugins.push(mentionPlugin_PREFIX_ONE);
         }

--- a/src/Service/draftEditor.service.tsx
+++ b/src/Service/draftEditor.service.tsx
@@ -214,10 +214,10 @@ const convertToHTMLString = (
                 return (
                     <span
                         className="hash-mention"
-                        title={dynamicMention ? entity.data.mention.title : null}
+                        title={dynamicMention ? entity.data.mention?.title : null}
                         style={{
                             ...mentionAnchorStyle,
-                            color: entity.data.mention.color,
+                            color: entity.data.mention?.color,
                             backgroundColor: 'transparent',
                         }}
                         data-value={JSON.stringify({
@@ -226,7 +226,7 @@ const convertToHTMLString = (
                             avatar: '',
                         })}
                     >
-                        {dynamicMention ? `#[${entity.data.mention.key}]` : originalText}
+                        {dynamicMention ? `#[${entity.data.mention?.key}]` : originalText}
                     </span>
                 );
             } else if (entity.type === 'link' || entity.type === 'LINK') {


### PR DESCRIPTION
# Changes Made On Draft Editor

1.  [x] Editor
2.  [ ] Toolbar

# Purpose of change

-   [ ] NEW FEATURE IMPLEMENTATION
-   [ ] CODE QUALITY IMPROVEMENT
-   [ ] BUG FIX
-   [ ] Version Updation

# Description of change
- use can pass decorator as props to customize editor string
- props
  decorators:[{
      strategy: findMentions, // function to identity which text to customize
      component: MentionComponentDom, render custom react component
   }

<!-- Use '@' to mention the reviewer -->
# Reviewer
