### PR TITLE
fix(mention): reverted mentionArrowNavigation flag

### DIFF
--- a/src/DraftEditor.tsx
+++ b/src/DraftEditor.tsx
@@ -76,7 +76,6 @@ export interface IDraftEditorProps {
     parsedValueMentionRequired?: boolean;
     mentionWidth?: { people: number; value?: number };
     onTab?: (e: React.KeyboardEvent<{}>) => void;
-    mentionArrowNavigation?: boolean;
 }
 
 export interface IContentTextChangeProps {
@@ -827,14 +826,12 @@ class DraftEditor extends Component<IDraftEditorProps, IDraftEditorState> {
             valueSuggestion,
             ValuePopOverProps,
             onValueMentionInput,
-            mentionArrowNavigation,
             mentionWidth = { people: 220, value: 120 },
         } = this.props;
         const { editorState, peopleSearchOpen, valueSearchOpen, suggestions, format } = this.state;
         const MentionComp = this.mentionSuggestionList?.MentionSuggestions;
         const ValueMentionComp = this.mentionSuggestionList?.ValueSuggestion;
         const isMentionOpen = peopleSearchOpen || valueSearchOpen;
-        const hasArrowNavigation = isMentionOpen && mentionArrowNavigation;
         let keyBindingFn = (isMentionOpen ? undefined : this.props.customKeyBinder ?? this.keyBindingFn) as unknown as (
             event: React.KeyboardEvent<Element>,
         ) => string;
@@ -849,9 +846,6 @@ class DraftEditor extends Component<IDraftEditorProps, IDraftEditorState> {
         const setFormat = this.setFormat;
         // decorator for link only works when its passed from `decorator` prop.
         const decorators = this.props.linkDecorator ? [this.props.linkDecorator] : [];
-        const otherProps = hasArrowNavigation
-            ? {}
-            : { keyBindingFn, onTab: this.onTab, handleReturn: this.handleReturn };
         return (
             <Fragment>
                 {!inplaceToolbar &&
@@ -865,7 +859,9 @@ class DraftEditor extends Component<IDraftEditorProps, IDraftEditorState> {
                     })}
                 <Editor
                     ref={this.editorRef}
-                    {...otherProps}
+                    keyBindingFn={keyBindingFn}
+                    handleReturn={this.handleReturn}
+                    onTab={this.onTab}
                     customStyleFn={resolveCustomStyleMap}
                     preserveSelectionOnBlur
                     stripPastedStyles


### PR DESCRIPTION
### **User description**
# Changes Made On Draft Editor

1.  [X] Editor
2.  [ ] Toolbar

# Purpose of change

-   [ ] NEW FEATURE IMPLEMENTATION
-   [ ] CODE QUALITY IMPROVEMENT
-   [X] BUG FIX
-   [ ] Version Updation

# Description of change
fix(mention): reverted mentionArrowNavigation flag

<!-- Use '@' to mention the reviewer -->
# Reviewer
@nsdevaraj , @jeffersonswartz


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the `mentionArrowNavigation` flag from the `DraftEditor` component and its props interface.
- Simplified the logic in the `DraftEditor` component by removing conditions and properties related to `mentionArrowNavigation`.
- Updated the `Editor` component instantiation to directly pass `keyBindingFn`, `handleReturn`, and `onTab` props.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DraftEditor.tsx</strong><dd><code>Remove `mentionArrowNavigation` flag and related logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/DraftEditor.tsx

<li>Removed the <code>mentionArrowNavigation</code> property from <code>IDraftEditorProps</code>.<br> <li> Updated the <code>DraftEditor</code> component to remove logic related to <br><code>mentionArrowNavigation</code>.<br> <li> Simplified the props passed to the <code>Editor</code> component.<br>


</details>


  </td>
  <td><a href="https://github.com/visualbis/draftjs/pull/158/files#diff-1f04a605e3deca0138e9d011ecdd50e5485c16b2520e93e7c7b7b7ae625a3d89">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information